### PR TITLE
CI: add make commands postgres macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,9 +198,22 @@ release:
 postgres-start:
 	sudo -u postgres PGDATA=pgsql PGPORT=5556 /usr/lib/postgresql/12/bin/pg_ctl start
 
+.PHONY: postgres-start-macos
+postgres-start-macos:
+	@if [ -f "pgsql/postmaster.pid" ]; then \
+		echo "PostgreSQL is already running or improperly shut down."; \
+		echo "If you're sure it's not running, try: make postgres-clean-lock"; \
+		exit 1; \
+	fi; \
+	PGDATA=pgsql PGPORT=5556 pg_ctl start
+
 .PHONY: postgres-stop
 postgres-stop:
 	sudo -u postgres PGDATA=pgsql PGPORT=5556 /usr/lib/postgresql/12/bin/pg_ctl stop
+
+.PHONY: postgres-stop-macos
+postgres-stop-macos:
+	PGDATA=pgsql PGPORT=5556 pg_ctl stop
 
 .PHONY: postgres-create
 postgres-create:
@@ -212,6 +225,17 @@ postgres-create:
 		sudo -u postgres PGDATA=pgsql PGPORT=5556 /usr/lib/postgresql/12/bin/pg_ctl start; \
 		sudo -u postgres PGDATA=pgsql PGPORT=5556 /usr/lib/postgresql/12/bin/createuser -s django; \
 		sudo -u postgres PGDATA=pgsql PGPORT=5556 /usr/lib/postgresql/12/bin/createdb -O django django; \
+	fi
+
+.PHONY: postgres-create-macos
+postgres-create-macos:
+	if [ -d "pgsql" ]; then \
+		echo "postgresql has already been initialized"; \
+	else \
+		initdb pgsql; \
+		PGDATA=pgsql PGPORT=5556 pg_ctl start; \
+		PGDATA=pgsql PGPORT=5556 createuser -s django; \
+		PGDATA=pgsql PGPORT=5556 createdb -O django django; \
 	fi
 
 .PHONY: local-a4

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ postgres-start-macos:
 		echo "If you're sure it's not running, try: make postgres-clean-lock"; \
 		exit 1; \
 	fi; \
-	PGDATA=pgsql PGPORT=5556 pg_ctl start
+	pg_ctl -D pgsql -o "-p 5556" start
 
 .PHONY: postgres-stop
 postgres-stop:
@@ -213,7 +213,7 @@ postgres-stop:
 
 .PHONY: postgres-stop-macos
 postgres-stop-macos:
-	PGDATA=pgsql PGPORT=5556 pg_ctl stop
+	pg_ctl -D pgsql -o "-p 5556" stop
 
 .PHONY: postgres-create
 postgres-create:

--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,7 @@ postgres-create-macos:
 		PGDATA=pgsql PGPORT=5556 pg_ctl start; \
 		PGDATA=pgsql PGPORT=5556 createuser -s django; \
 		PGDATA=pgsql PGPORT=5556 createdb -O django django; \
+		psql -U django -d django -c "CREATE EXTENSION IF NOT EXISTS postgis;"; \
 	fi
 
 .PHONY: local-a4

--- a/README.md
+++ b/README.md
@@ -90,14 +90,28 @@ We take security seriously. If you find any security issues, please feel free to
 
 ### Use postgresql database for testing
 
+#### MacOS dependencies
+
+```
+brew install postgresql
+brew install postgis
+```
+
 run the following command once:
 ```
-make postgres-create
+make postgres-create 
 ```
+
+or
+
+```
+make postgres-create-macos
+```
+
 to start the test server with postgresql, run:
 ```
 export DATABASE=postgresql
-make postgres-start
+make postgres-start # (or make postgres-start-macos)
 make watch
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ adhocracy+ is designed to make online participation easy and accessible to every
  * libpq (only if postgres should be used)
  * pillow-heif (required for macOS M1 Monterey and newer versions)
  * libpq (only if PostgreSQL is used)
+ * postgis (only if PostgreSQL is used)
+ * libmagic (macOS)
  * GDAL
  * SpatiaLite [with JSON1 enabled](https://code.djangoproject.com/wiki/JSON1Extension) (only if SpatiaLite is used for local development)
  * Redis (required in production, optional for development)

--- a/changelog/250619.md
+++ b/changelog/250619.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Updated Makefile with additional commands for postgres on macos


### PR DESCRIPTION
Next step would to be make unified platform agnostic commands, lets create a ticket for this.


**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog
